### PR TITLE
bugfix: avoid panic by making blocking request

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -363,8 +363,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "632a8cd0f2a4b3fdea1657f08bde063848c3bd00f9bbf6e256b8be78802e624b"
 dependencies = [
  "futures-core",
+ "futures-io",
  "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
  "slab",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ serde = { version = "1.0", features = ["derive"] }
 tokio = { version = "1.5", features = ["sync", "macros", "rt-multi-thread"] }
 log = "0.4.17"
 env_logger = "0.9.3"
-reqwest = "0.11.10"
+reqwest = { version = "0.11.10", features = ["blocking"] }
 clap = { version = "4.1.8", features = ["derive"] }
 indoc = "1"
 once_cell = "1.17"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,8 @@
+use std::boxed::Box;
 use std::cell::Cell;
 use std::error::Error;
 use std::net::SocketAddr;
 use std::sync::Mutex;
-use std::{boxed::Box, net::Shutdown};
 
 use clap::Parser;
 use indoc::indoc;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,8 @@
-use std::{boxed::Box, net::Shutdown};
 use std::cell::Cell;
 use std::error::Error;
 use std::net::SocketAddr;
 use std::sync::Mutex;
+use std::{boxed::Box, net::Shutdown};
 
 use clap::Parser;
 use indoc::indoc;

--- a/src/main.rs
+++ b/src/main.rs
@@ -139,7 +139,7 @@ async fn main() -> Result<()> {
     } else {
         log::info!("issuing upstream shutdown request: {}", shutdown_url);
         let shutdown_thd = std::thread::spawn(move || {
-            let shutdown_resp = reqwest::blocking::get(&shutdown_url);
+            let shutdown_resp = reqwest::blocking::get(shutdown_url);
             match shutdown_resp {
                 Ok(shutdown_resp) => {
                     let shutdown_text = shutdown_resp.text();

--- a/src/main.rs
+++ b/src/main.rs
@@ -138,7 +138,7 @@ async fn main() -> Result<()> {
         log::info!("not issuing upstream shutdown request");
     } else {
         log::info!("issuing upstream shutdown request: {}", shutdown_url);
-        let shutdown_resp = reqwest::get(&shutdown_url).await?.text().await?;
+        let shutdown_resp = reqwest::blocking::get(&shutdown_url)?.text()?;
         log::info!("upstream shutdown response: {}", shutdown_resp);
     }
 

--- a/upstream.py
+++ b/upstream.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+
+import sys
+
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+HOSTNAME = "127.23.8.31"
+SERVERPORT = 8080
+
+
+class Server(BaseHTTPRequestHandler):
+    def do_GET(self):
+        self.send_response(200)
+        self.send_header("Content-type", "text/plain")
+        self.end_headers()
+        if self.path == '/shutdown_123456':
+            self.wfile.write(b"shutting down")
+            sys.exit(0)
+        else:
+            self.wfile.write(b"Hi")
+
+
+if __name__ == "__main__":
+
+    webServer = HTTPServer((HOSTNAME, SERVERPORT), Server)
+    print("Server started http://%s:%s" % (HOSTNAME, SERVERPORT))
+
+    try:
+        webServer.serve_forever()
+    except KeyboardInterrupt:
+        pass
+
+    webServer.server_close()
+    print("Server stopped.")


### PR DESCRIPTION
Tokio shutdown behavior seems to have changed at some point so that we can no longer issue requests while tearing down.  To work around this, we launch a thread and issue a request using a blocking module.

Test using a dummy upstream server (see `upstream.py`) and running server as follows:

```
RUST_LOG=debug \
  REV_PROXY_LISTEN_ADDRESS=0.0.0.0:8888 \
  REV_PROXY_BASE_PATH=/ \
  REV_PROXY_UPSTREAM_URL=http://127.23.8.31:8080 \
  REV_PROXY_SHUTDOWN_KEY=123456 \
  REV_PROXY_SHUTDOWN_URL=http://127.23.8.31:8080/shutdown_ \
      cargo run --
```

Run the upstream server:

```
python upstream.py
```

Then issue shutdown to `rev-proxy`:

```
pkill rev-proxy
```

Server output from `rev-proxy`:

```
[2023-09-01T02:58:49Z INFO  rev_proxy] listening on: 0.0.0.0:8888...
[2023-09-01T02:58:59Z DEBUG rev_proxy] got shutdown signal, waiting for all open connections to complete...
[2023-09-01T02:58:59Z DEBUG hyper::server::shutdown] signal received, starting graceful shutdown
[2023-09-01T02:58:59Z INFO  rev_proxy] shutting down...
[2023-09-01T02:58:59Z INFO  rev_proxy] issuing upstream shutdown request: http://127.23.8.31:8080/shutdown_123456
[2023-09-01T02:58:59Z DEBUG reqwest::connect] starting new connection: http://127.23.8.31:8080/
[2023-09-01T02:58:59Z DEBUG hyper::client::connect::http] connecting to 127.23.8.31:8080
[2023-09-01T02:58:59Z DEBUG hyper::client::connect::http] connected to 127.23.8.31:8080
[2023-09-01T02:58:59Z DEBUG hyper::proto::h1::io] flushed 70 bytes
[2023-09-01T02:58:59Z DEBUG hyper::proto::h1::io] parsed 3 headers
[2023-09-01T02:58:59Z DEBUG hyper::proto::h1::conn] incoming body is close-delimited
[2023-09-01T02:58:59Z DEBUG reqwest::async_impl::client] response '200 OK' for http://127.23.8.31:8080/shutdown_123456
[2023-09-01T02:58:59Z DEBUG hyper::proto::h1::conn] incoming body completed
[2023-09-01T02:58:59Z INFO  rev_proxy] upstream shutdown response: shutting down
```

Server output for fake upstream:

```
❯ python upstream.py
Server started http://127.23.8.31:8080
127.0.0.1 - - [31/Aug/2023 19:45:07] "GET / HTTP/1.1" 200 -
127.0.0.1 - - [31/Aug/2023 19:45:07] "GET /favicon.ico HTTP/1.1" 200 -
127.0.0.1 - - [31/Aug/2023 19:45:16] "GET /shutdown HTTP/1.1" 200 -
127.0.0.1 - - [31/Aug/2023 19:45:17] "GET /favicon.ico HTTP/1.1" 200 -
127.0.0.1 - - [31/Aug/2023 19:58:59] "GET /shutdown_123456 HTTP/1.1" 200 -
```

Making requests against `rev-proxy` server (which forwards to upstream):

```
❯ curl -v http://127.0.0.1:8888/
*   Trying 127.0.0.1:8888...
* Connected to 127.0.0.1 (127.0.0.1) port 8888 (#0)
> GET / HTTP/1.1
> Host: 127.0.0.1:8888
> User-Agent: curl/7.81.0
> Accept: */*
>
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< server: BaseHTTP/0.6 Python/3.9.5
< date: Fri, 01 Sep 2023 03:09:01 GMT
< content-type: text/plain
< content-length: 2
<
* Connection #0 to host 127.0.0.1 left intact
Hi
```